### PR TITLE
🎨 Wrong words for today on stats formatted differently

### DIFF
--- a/app/src/main/java/com/arnyminerz/paraulogic/ui/screen/StatsScreen.kt
+++ b/app/src/main/java/com/arnyminerz/paraulogic/ui/screen/StatsScreen.kt
@@ -205,15 +205,26 @@ fun StatsScreen(
                     Text(
                         modifier = Modifier.padding(8.dp),
                         text = stringResource(
-                            R.string.stats_invalid_words,
+                            if (isToday)
+                                R.string.stats_today_invalid_words
+                            else
+                                R.string.stats_invalid_words,
                             dayWrongWords.size,
                             maxWordsCount,
-                            if (maxWordsCount < 5)
-                                stringResource(R.string.stats_invalid_words_comment_1)
-                            else if (maxWordsCount < 10)
-                                stringResource(R.string.stats_invalid_words_comment_2)
+                            if (isToday)
+                                if (maxWordsCount < 5)
+                                    stringResource(R.string.stats_today_invalid_words_comment_1)
+                                else if (maxWordsCount < 10)
+                                    stringResource(R.string.stats_today_invalid_words_comment_2)
+                                else
+                                    stringResource(R.string.stats_today_invalid_words_comment_3)
                             else
-                                stringResource(R.string.stats_invalid_words_comment_3)
+                                if (maxWordsCount < 5)
+                                    stringResource(R.string.stats_invalid_words_comment_1)
+                                else if (maxWordsCount < 10)
+                                    stringResource(R.string.stats_invalid_words_comment_2)
+                                else
+                                    stringResource(R.string.stats_invalid_words_comment_3)
                         )
                     )
                 }

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -67,4 +67,8 @@
     <string name="settings_category_general">General</string>
     <string name="settings_general_language_title">Idioma</string>
     <string name="settings_general_language_summary">Selecciona el idioma que mostrar a l\'app</string>
+    <string name="stats_today_invalid_words">Hui has aconseguit inventar-te %d paraules, i has repetit una d\'elles %d vegades. %s</string>
+    <string name="stats_today_invalid_words_comment_1">Estàs bé?</string>
+    <string name="stats_today_invalid_words_comment_2">Val, ja està bé.</string>
+    <string name="stats_today_invalid_words_comment_3">De debò, hui no és el teu dia.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -86,4 +86,9 @@
     <string name="stats_invalid_words_comment_1">What a tough day.</string>
     <string name="stats_invalid_words_comment_2">You were inspired that day 🥴…</string>
     <string name="stats_invalid_words_comment_3">Did you really think that was going to work?</string>
+
+    <string name="stats_today_invalid_words">Today day you have managed to make up %d words, repeating one of them up to %d times. %s</string>
+    <string name="stats_today_invalid_words_comment_1">Are you okay?</string>
+    <string name="stats_today_invalid_words_comment_2">Okay, just stop trying.</string>
+    <string name="stats_today_invalid_words_comment_3">Seriously, today is not your day.</string>
 </resources>


### PR DESCRIPTION
On the stats screen, whenever you are checking for wrong words you have made today, it's shown with a "today you have made up..." message, instead of "that day...".